### PR TITLE
Make PhpStorm happy

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../tsconfig.json",
   "include": [
     "../node_modules/cypress",
-    "*/*.ts"
+    "./*/*.ts"
   ]
 }


### PR DESCRIPTION
TypeScript works just fine with this repo, but PhpStorm's TypeScript plugin goes crazy:
- clone the repo
- open it with PhpStorm
- open a Jest test first - all good
- then open a Cypress test - PhpStorm shows errors because of types conflict

I know, this is an issue of PhpStorm, but the fix that I have found is super easy, so maybe you can commit it?