### PR TITLE
Set noEmit to false explicitly

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
   "include": [
     "../node_modules/cypress",
     "./*/*.ts"


### PR DESCRIPTION
I just spent an hour debugging why I was getting this error:

```
./cypress/integration/join-space.ts
Module build failed (from ./node_modules/ts-loader/index.js):
Error: TypeScript emitted no output for [specFilePath/spec.ts].
 @ multi ./cypress/integration/join-space.ts main[0]
```